### PR TITLE
feat: deal with new kustomize versioning scheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,4 +12,4 @@ asdf plugin-add kustomize https://github.com/Banno/asdf-kustomize.git
 
 ## Use
 
-Check out the [asdf](https://github.com/asdf-vm/asdf) readme for instructions on how to install and manage versions of HashiCorp tools.
+Check out the [asdf](https://github.com/asdf-vm/asdf) readme for instructions on how to install and manage versions of Kustomize.

--- a/bin/install
+++ b/bin/install
@@ -39,6 +39,7 @@ install_kustomize() {
   local install_type=$1
   local version=$2
   local install_path=$3
+  local tmp_download_dir=$4
   local bin_install_path="$install_path/bin"
   local download_url="$(get_download_url $version)"
 
@@ -46,7 +47,13 @@ install_kustomize() {
 
   local bin_path="${bin_install_path}/kustomize"
   echo "Downloading kustomize from ${download_url}"
-  curl -s -L "$download_url" -o "$bin_path"
+  if [[ "$download_url" == *"tar.gz"* ]]; then
+    curl -s -L "$download_url" -o "$tmp_download_dir/kustomize.tgz"
+    tar xpf "$tmp_download_dir/kustomize.tgz" -C "$tmp_download_dir"
+    cp "$tmp_download_dir/kustomize" "$bin_path"
+  else
+    curl -s -L "$download_url" -o "$bin_path"
+  fi
   chmod +x $bin_path
 }
 
@@ -67,9 +74,21 @@ get_download_url() {
   if [[ "$op" == '<' ]]; then
     echo "https://github.com/kubernetes-sigs/kustomize/releases/download/v${version}/kustomize_${version}_${platform}_amd64"
   else
-    echo "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv${version}/kustomize_kustomize.v${version}_${platform}_amd64"
+    vercomp "$version" "3.3.0"
+    case $? in
+    0) op='=' ;;
+    1) op='>' ;;
+    2) op='<' ;;
+    esac
+    if [[ "$op" == '<' ]]; then
+      echo "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv${version}/kustomize_kustomize.v${version}_${platform}_amd64"
+    else
+      echo "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv${version}/kustomize_v${version}_${platform}_amd64.tar.gz"
+    fi
   fi
 
 }
 
-install_kustomize $ASDF_INSTALL_TYPE $ASDF_INSTALL_VERSION $ASDF_INSTALL_PATH
+tmp_download_dir="$(mktemp -d -t 'asdf_XXXXXXXX')"
+trap 'rm -rf "${tmp_download_dir}"' EXIT
+install_kustomize $ASDF_INSTALL_TYPE $ASDF_INSTALL_VERSION $ASDF_INSTALL_PATH $tmp_download_dir

--- a/bin/install
+++ b/bin/install
@@ -5,8 +5,35 @@ set -o pipefail
 
 ASDF_INSTALL_TYPE=${ASDF_INSTALL_TYPE:-version  }
 TMPDIR=${TMPDIR:-/tmp}
-[ -n "$ASDF_INSTALL_VERSION" ] || (>&2 echo 'Missing ASDF_INSTALL_VERSION' && exit 1)
-[ -n "$ASDF_INSTALL_PATH" ] || (>&2 echo 'Missing ASDF_INSTALL_PATH' && exit 1)
+[ -n "$ASDF_INSTALL_VERSION" ] || (echo >&2 'Missing ASDF_INSTALL_VERSION' && exit 1)
+[ -n "$ASDF_INSTALL_PATH" ] || (echo >&2 'Missing ASDF_INSTALL_PATH' && exit 1)
+
+# from https://stackoverflow.com/questions/4023830/how-to-compare-two-strings-in-dot-separated-version-format-in-bash
+function vercomp() {
+  if [[ "$1" == "$2" ]]; then
+    return 0
+  fi
+  local IFS=.
+  # shellcheck disable=SC2206
+  local i ver1=($1) ver2=($2)
+  # fill empty fields in ver1 with zeros
+  for ((i = ${#ver1[@]}; i < ${#ver2[@]}; i++)); do
+    ver1[i]=0
+  done
+  for ((i = 0; i < ${#ver1[@]}; i++)); do
+    if [[ -z ${ver2[i]} ]]; then
+      # fill empty fields in ver2 with zeros
+      ver2[i]=0
+    fi
+    if ((10#${ver1[i]} > 10#${ver2[i]})); then
+      return 1
+    fi
+    if ((10#${ver1[i]} < 10#${ver2[i]})); then
+      return 2
+    fi
+  done
+  return 0
+}
 
 install_kustomize() {
   local install_type=$1
@@ -30,7 +57,19 @@ get_arch() {
 get_download_url() {
   local version="$1"
   local platform="$(get_arch)"
-  echo "https://github.com/kubernetes-sigs/kustomize/releases/download/v${version}/kustomize_${version}_${platform}_amd64"
+
+  vercomp "$version" "3.2.1"
+  case $? in
+  0) op='=' ;;
+  1) op='>' ;;
+  2) op='<' ;;
+  esac
+  if [[ "$op" == '<' ]]; then
+    echo "https://github.com/kubernetes-sigs/kustomize/releases/download/v${version}/kustomize_${version}_${platform}_amd64"
+  else
+    echo "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv${version}/kustomize_kustomize.v${version}_${platform}_amd64"
+  fi
+
 }
 
 install_kustomize $ASDF_INSTALL_TYPE $ASDF_INSTALL_VERSION $ASDF_INSTALL_PATH

--- a/bin/list-all
+++ b/bin/list-all
@@ -9,10 +9,12 @@ cmd="$cmd $releases_path"
 
 # stolen from https://github.com/rbenv/ruby-build/pull/631/files#diff-fdcfb8a18714b33b07529b7d02b54f1dR942
 function sort_versions() {
-  sed 'h; s/[+-]/./g; s/.p\([[:digit:]]\)/.z\1/; s/$/.z/; G; s/\n/ /' | \
+  sed 'h; s/[+-]/./g; s/.p\([[:digit:]]\)/.z\1/; s/$/.z/; G; s/\n/ /' |
     LC_ALL=C sort -t. -k 1,1 -k 2,2n -k 3,3n -k 4,4n -k 5,5n | awk '{print $2}'
 }
 
-# Fetch all tag names, and get only second column. Then remove all unnecesary characters.
-versions=$(eval $cmd | grep -oE "tag_name\": *\".{1,15}\"," | sed 's/tag_name\": *\"v//;s/\",//' | sort_versions)
-echo $versions
+# Versions till 3.2.0 are advertised with tag v${version}
+# Versions starting from 3.2.1 are advertised with tag kustomize/v${version}
+versions_till_320=$(eval $cmd | grep -oE "tag_name\": *\"v[0-9].*\"," | grep -vE "v3\.3.*" | sed 's/tag_name\": *\"v//;s/\",//' | sort_versions)
+versions_post_321=$(eval $cmd | grep -oE "tag_name\": *\"kustomize/v[0-9].*\"," | sed 's/tag_name\": *\"kustomize\/v//;s/\",//' | sort_versions)
+echo $versions_till_320 $versions_post_321

--- a/bin/list-all
+++ b/bin/list-all
@@ -15,6 +15,6 @@ function sort_versions() {
 
 # Versions till 3.2.0 are advertised with tag v${version}
 # Versions starting from 3.2.1 are advertised with tag kustomize/v${version}
-versions_till_320=$(eval $cmd | grep -oE "tag_name\": *\"v[0-9].*\"," | grep -vE "v3\.3.*" | sed 's/tag_name\": *\"v//;s/\",//' | sort_versions)
+versions_till_320=$(eval $cmd | grep -oE "tag_name\": *\"v[0-9].*\"," | grep -vE "(v3\.[3-9]|v[4-9]).*" | sed 's/tag_name\": *\"v//;s/\",//' | sort_versions)
 versions_post_321=$(eval $cmd | grep -oE "tag_name\": *\"kustomize/v[0-9].*\"," | sed 's/tag_name\": *\"kustomize\/v//;s/\",//' | sort_versions)
 echo $versions_till_320 $versions_post_321


### PR DESCRIPTION
- Versions till 3.2.0 are advertised with tag v${version} (so the tag advertised as v3.3.0 is NOT a valid kustomize version)
- Versions starting from 3.2.1 are advertised with tag kustomize/v${version}

This is a proposal to take #1  into account