### PR TITLE
Get more releases from releases endpoint

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -5,7 +5,7 @@ cmd="curl -s"
 if [ -n "$OAUTH_TOKEN" ]; then
   cmd="$cmd -H 'Authorization: token $OAUTH_TOKEN'"
 fi
-cmd="$cmd $releases_path"
+cmd="$cmd '${releases_path}?per_page=100'"
 
 # stolen from https://github.com/rbenv/ruby-build/pull/631/files#diff-fdcfb8a18714b33b07529b7d02b54f1dR942
 function sort_versions() {


### PR DESCRIPTION
The releases response is paginated, and this is only getting page 1. This change doesn't fetch the subsequent pages, but it does get more releases in that first page.