### PR TITLE
Add support for non-mac arm64 devices

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -64,12 +64,14 @@ get_platform() {
 get_arch() {
   local arch; arch=$(uname -m | tr '[:upper:]' '[:lower:]')
   case ${arch} in
+  arm64) # m1 macs
+    arch='arm64';;
+  aarch64) # all other arm64 devices
+    arch='arm64';;
   x86_64)
-    arch='amd64'
-    ;;
-  arm64)
-    arch='arm64'
-    ;;
+    arch='amd64';;
+  *) # fallback
+    arch='amd64';;
   esac
 
   echo "${arch}"


### PR DESCRIPTION
Arm64 support was recently added, but it only works for m1 macs. This change will allow the `uname` lookup of the host's arch to include non-mac arm64 devices as well as provide a fallback to amd64 if the arch isn't in the switch case options.

Problem:

`Downloading kustomize from https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv4.5.3/kustomize_v4.5.3_linux_aarch64.tar.gz`
`tar: This does not look like a tar archive`


Testing:

`$ asdf plugin add kustomize https://github.com/mathew-fleisch/asdf-kustomize.git`
`$ asdf install kustomize latest`
`Downloading kustomize from https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv4.5.4/kustomize_v4.5.4_linux_arm64.tar.gz`
`$ asdf global kustomize latest`
`$ kustomize version`
`{Version:kustomize/v4.5.4 GitCommit:cf3a452ddd6f83945d39d582243b8592ec627ae3 BuildDate:2022-03-28T23:12:45Z GoOs:linux GoArch:arm64}`