### PR TITLE
Support overriding system cpu arch

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,7 @@ asdf plugin-add kustomize https://github.com/Banno/asdf-kustomize.git
 ## Use
 
 Check out the [asdf](https://github.com/asdf-vm/asdf) readme for instructions on how to install and manage versions of Kustomize.
+
+### Override CPU arch version
+
+Set env variable `ASDF_KUSTOMIZE_OVERWRITE_ARCH` to desired arch if wish to override system default.

--- a/bin/install
+++ b/bin/install
@@ -74,7 +74,7 @@ get_arch() {
     arch='amd64';;
   esac
 
-  echo "${arch}"
+  echo "${ASDF_KUSTOMIZE_OVERWRITE_ARCH:- $arch}"
 }
 
 get_download_url() {


### PR DESCRIPTION
Minor patch to support overriding detected system cpu arch in same manner as some other asdf-plugins such as [helm](https://github.com/Antiarchitect/asdf-helm) and [terraform](https://github.com/asdf-community/asdf-hashicorp).

Use case is to support arm macbooks to install older versions specified in `.tool-versions` that don't have an arm build without having to update repo version.